### PR TITLE
Where has undefined foreign key

### DIFF
--- a/index.js
+++ b/index.js
@@ -656,12 +656,12 @@ module.exports = function(Bookshelf, options) {
     delete relatedQuery.relatedData;
 
     // get the columns
-    let relatedFkAttribute = rd.foreignKey;
+    let relatedFkAttribute = rd.key('foreignKey');
     let relatedIdAttribute = rd.targetIdAttribute;
 
     // build the pivot table query
-    let pivotQuery = knex.select([rd.foreignKey, rd.otherKey])
-      .from(rd.joinTableName).whereIn(rd.foreignKey, ids);
+    let pivotQuery = knex.select([rd.key('foreignKey'), rd.otherKey])
+      .from(rd.joinTableName).whereIn(rd.key('foreignKey'), ids);
 
     // fetch from pivot table
     let pivotRows = await pivotQuery;
@@ -670,7 +670,7 @@ module.exports = function(Bookshelf, options) {
     let foreignKeyIndex = new Map();
     let otherKeySet = new Set();
     for (let pivotRow of pivotRows) {
-      let foreignKeyValue = pivotRow[rd.foreignKey];
+      let foreignKeyValue = pivotRow[rd.key('foreignKey')];
       if (foreignKeyValue === null) continue;
       let otherKeyValue = pivotRow[rd.otherKey];
       if (otherKeyValue === null) continue;
@@ -744,7 +744,7 @@ module.exports = function(Bookshelf, options) {
     delete relatedQuery.relatedData;
 
     // get the columns
-    let relatedFkAttribute = rd.foreignKey;
+    let relatedFkAttribute = rd.key('foreignKey');
     let relatedIdAttribute = rd.targetIdAttribute;
 
     // apply the whereIn constraint to the relatedQuery
@@ -807,7 +807,7 @@ module.exports = function(Bookshelf, options) {
     delete relatedQuery.relatedData;
 
     // get the columns
-    let relatedFkAttribute = rd.foreignKey;
+    let relatedFkAttribute = rd.key('foreignKey');
     let relatedIdAttribute = rd.targetIdAttribute;
 
     // build the fk ids array
@@ -1063,7 +1063,7 @@ module.exports = function(Bookshelf, options) {
         // Pivot table part.
         subquery = knex.select(rd.otherKey)
           .from(rd.joinTableName)
-          .whereIn(rd.foreignKey, subquery);
+          .whereIn(rd.key('foreignKey'), subquery);
 
         // BelongsTo part.
         bookQuery.whereIn(rd.targetIdAttribute, subquery);
@@ -1072,13 +1072,13 @@ module.exports = function(Bookshelf, options) {
         if (isString(subquery))
           subquery = knex.raw('(??.??)', [subquery, Model.idAttribute]);
         else subquery = subquery.select(Model.idAttribute);
-        bookQuery.whereIn(rd.foreignKey, subquery);
+        bookQuery.whereIn(rd.key('foreignKey'), subquery);
         break;
       case 'belongsTo':
       case 'hasOne':
         if (isString(subquery))
-          subquery = knex.raw('??.??', [subquery, rd.foreignKey]);
-        else subquery = subquery.select(rd.foreignKey);
+          subquery = knex.raw('??.??', [subquery, rd.key('foreignKey')]);
+        else subquery = subquery.select(rd.key('foreignKey'));
         bookQuery.whereIn(rd.targetIdAttribute, subquery);
         break;
       default:

--- a/migrations/20171130162127_create_person_table.js
+++ b/migrations/20171130162127_create_person_table.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = async function(knex, Promise) {
+  await knex.schema.createTable('person', function(table) {
+    table.charset('utf8');
+    table.collate('utf8_unicode_ci');
+
+    // User data.
+    table.increments('idAttr').unsigned().primary();
+
+    // Soft delete.
+    table.dateTime('deletedAt').nullable().index();
+
+    // Timestamps.
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now()).index();
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = async function(knex, Promise) {
+  await knex.schema.dropTable('person');
+};

--- a/migrations/20171130162239_create_dog_table.js
+++ b/migrations/20171130162239_create_dog_table.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = async function(knex, Promise) {
+  await knex.schema.createTable('dog', function(table) {
+    table.charset('utf8');
+    table.collate('utf8_unicode_ci');
+
+    table.increments('idAttr').unsigned().primary();
+    table.integer('person_id').unsigned().notNullable().references('person.idAttr').onUpdate('CASCADE').onDelete('RESTRICT');
+
+    // Soft delete.
+    table.dateTime('deletedAt').nullable().index();
+
+    // Timestamps.
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now()).index();
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = async function(knex, Promise) {
+  await knex.schema.dropTable('dog');
+};

--- a/migrations/20171130162239_create_dogs_table.js
+++ b/migrations/20171130162239_create_dogs_table.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = async function(knex, Promise) {
+  await knex.schema.createTable('dog', function(table) {
+    table.charset('utf8');
+    table.collate('utf8_unicode_ci');
+
+    table.increments('idAttr').unsigned().primary();
+    table.integer('person_idAttr').unsigned().notNullable().references('person.idAttr').onUpdate('CASCADE').onDelete('RESTRICT');
+
+    // Soft delete.
+    table.dateTime('deletedAt').nullable().index();
+
+    // Timestamps.
+    table.dateTime('createdAt').notNullable().defaultTo(knex.fn.now()).index();
+    table.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = async function(knex, Promise) {
+  await knex.schema.dropTable('dog');
+};

--- a/models/dog.js
+++ b/models/dog.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Bookshelf = require('../bookshelf.js');
+
+require('./user');
+require('./comment');
+require('./tag');
+require('./rating');
+
+module.exports = Bookshelf.model('Dog', {
+  tableName: 'dog',
+  idAttribute: 'idAttr',
+  hasTimestamps: ['createdAt', 'updatedAt'],
+  hidden: [
+    'deletedAt',
+  ],
+  softDelete: true,
+
+});

--- a/models/person.js
+++ b/models/person.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Bookshelf = require('../bookshelf.js');
+
+require('./dog');
+
+module.exports = Bookshelf.model('Person', {
+  tableName: 'person',
+  idAttribute: 'idAttr',
+  hasTimestamps: ['createdAt', 'updatedAt'],
+  hidden: [
+    'deletedAt',
+  ],
+  softDelete: true,
+
+  dogs: function() {
+    return this.hasMany('Dog');
+  },
+
+});

--- a/tests/07_where_has_test.js
+++ b/tests/07_where_has_test.js
@@ -22,6 +22,8 @@ const Tag = require('../models/tag');
 const User = require('../models/user');
 const Empty = require('../models/empty');
 
+const Person = require('../models/person');
+
 function modelAttrs(model) {
   return model.attributes;
 }
@@ -116,6 +118,9 @@ exports.test = async function() {
     assert.equal(user.postsCount > 0 && (user.deletedAt !== null),
       usersIndex.has(user.idAttr));
   }
+
+  assert.equal((await Person.has('dogs').buildQuery()).query.toString(),
+    'select `person`.* from `person` where (exists (select * from `dog` where `person_idAttr` in (`person`.`idAttr`) and `dog`.`deletedAt` is null)) and `person`.`deletedAt` is null');
 
   assert.equal((await User.has('posts').buildQuery()).query.toString(),
     'select `users`.* from `users` where (exists (select * from `posts` where `createdById` in (`users`.`idAttr`) and `posts`.`deletedAt` is null)) and `users`.`deletedAt` is null');


### PR DESCRIPTION
Bookshelf has a default behavior for hasMany relations which is to use a
foreign key built from attributes, however the current building of
whereHas queries doesn't work with this behavior and creates invalid
SQL:

> ForeignKey in the Target model. By default, the foreignKey is assumed to be the singular form of this model's tableName, followed by _id / _{{idAttribute}}.

The added test fails with this message due to that issue, but the 2nd commit fixes the test:

	[FAILED on TEST] 07_where_has_test
	{ AssertionError [ERR_ASSERTION]: 'select `person`.* from `person` where (exists (select * from `dog` where `undefined` in (`person`.`idAttr`) and `dog`.`deletedA == 'select `person`.* from `person` where (exists (select * from `dog` where `person_idAttr` in (`person`.`idAttr`) and `dog`.`dele
	    at Object.exports.test (/Users/patrick/src/bookshelf-eloquent/tests/07_where_has_test.js:122:10)
	    at <anonymous>
	  generatedMessage: true,
	  name: 'AssertionError [ERR_ASSERTION]',
	  code: 'ERR_ASSERTION',
	  actual: 'select `person`.* from `person` where (exists (select * from `dog` where `undefined` in (`person`.`idAttr`) and `dog`.`deletedAt` is null)) and `person`.`deletedAt` is null',
	  expected: 'select `person`.* from `person` where (exists (select * from `dog` where `person_idAttr` in (`person`.`idAttr`) and `dog`.`deletedAt` is null)) and `person`.`deletedAt` is null',
	  operator: '==' }